### PR TITLE
Text shadow for the intro body, right now the text blends with the new background

### DIFF
--- a/css/grayscale.css
+++ b/css/grayscale.css
@@ -154,6 +154,7 @@ a:focus {
 .intro .intro-body {
     display: table-cell;
     vertical-align: middle;
+    text-shadow: 0px 0px 20px #000000;
 }
 
 .intro .intro-body .brand-heading {


### PR DESCRIPTION
Before:
<img width="1417" alt="Screenshot 2020-04-26 at 7 17 53 PM" src="https://user-images.githubusercontent.com/8610709/80309494-0a6deb80-87f3-11ea-8c44-77dad68b1623.png">
After:
<img width="1427" alt="Screenshot 2020-04-26 at 7 18 16 PM" src="https://user-images.githubusercontent.com/8610709/80309498-0e017280-87f3-11ea-8e09-386fee8ace20.png">
